### PR TITLE
Add option to list CVES in reverse order

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run golangci-lint

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Set up Go"
         uses: actions/setup-go@v4
         with: 
-          go-version: 1.19
+          go-version: 1.21
       
       - name: "Create release on GitHub"
         uses: goreleaser/goreleaser-action@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/templates-stats
 
-go 1.19
+go 1.21
 
 require (
 	github.com/olekukonko/tablewriter v0.0.5

--- a/main.go
+++ b/main.go
@@ -333,14 +333,14 @@ func printTemplateStats() {
 		fields := strings.Split(*includeFields, ",")
 		fields = sliceutil.Dedupe(fields)
 		for _, cve := range cveList {
-			resultWriter.Write([]byte(formatCveItem(cve, fields)))
+			_, _ = resultWriter.Write([]byte(formatCveItem(cve, fields)))
 		}
 		*count = *count - len(cveList)
 		if hasTopFilter && *count >= 0 {
 			nonCveList = nonCveList[:*count]
 		}
 		for _, nc := range nonCveList {
-			resultWriter.Write([]byte(formatNonCveItem(nc, fields)))
+			_, _ = resultWriter.Write([]byte(formatNonCveItem(nc, fields)))
 		}
 		os.Exit(0)
 	}

--- a/main.go
+++ b/main.go
@@ -121,7 +121,14 @@ func (c CveList) Less(i, j int) bool {
 	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
 		return c[i].CveID > c[j].CveID
 	}
-	return firstYearPart >= secondYearPart && firstNumPart >= secondNumPart
+	if firstYearPart > secondYearPart {
+		return true
+	} else if firstYearPart == secondYearPart {
+		if firstNumPart > secondNumPart {
+			return true
+		}
+	}
+	return false
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -104,9 +104,25 @@ type CveItem struct {
 
 type CveList []CveItem
 
-func (c CveList) Len() int           { return len(c) }
-func (c CveList) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c CveList) Less(i, j int) bool { return c[i].CveID > c[j].CveID }
+func (c CveList) Len() int      { return len(c) }
+func (c CveList) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c CveList) Less(i, j int) bool {
+	first := strings.Split(c[i].CveID, "-")
+	second := strings.Split(c[j].CveID, "-")
+	if len(first) < 1 || len(second) < 1 && len(first) != len(second) {
+		return c[i].CveID > c[j].CveID
+	}
+	var err1, err2, err3, err4 error
+	var firstYearPart, firstNumPart, secondYearPart, secondNumPart int
+	firstYearPart, err1 = strconv.Atoi(first[1])
+	firstNumPart, err2 = strconv.Atoi(first[2])
+	secondYearPart, err3 = strconv.Atoi(second[1])
+	secondNumPart, err4 = strconv.Atoi(second[2])
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return c[i].CveID > c[j].CveID
+	}
+	return firstYearPart >= secondYearPart && firstNumPart >= secondNumPart
+}
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
- closes #3 

```console
$ ~/templates-stats/templates-stats -path . -lcr -fields author,severit -top 10
[CVE-2024-3400] GlobalProtect - OS Command Injection (@salts, @parthmalhotra)
[CVE-2024-3273] D-Link Network Attached Storage - Command Injection and Backdoor Account (@pussycat0x)
[CVE-2024-3094] XZ - Embedded Malicious Code (@pdteam)
[CVE-2024-29269] Telesquare TLR-2005KSH  - Remote Command Execution (@ritikchaddha)
[CVE-2024-29059] .NET Framework - Leaking ObjRefs via HTTP .NET Remoting (@iamnoooob, @rootxharsh, @DhiyaneshDk, @pdresearch)
[CVE-2024-2879] WordPress Plugin LayerSlider 7.9.11-7.10.0 - SQL Injection (@d4ly)
[CVE-2024-28734] Coda v.2024Q1 - Cross-Site Scripting (@Kazgangap)
[CVE-2024-28255] OpenMetadata - Authentication Bypass (@DhiyaneshDK, @iamnooob)
[CVE-2024-27954] WordPress Automatic Plugin <3.92.1 - Arbitrary File Download and SSRF (@iamnoooob, @rootxharsh, @pdresearch)
[CVE-2024-27564] ChatGPT个人专用版 - Server Side Request Forgery (@DhiyaneshDK)
```